### PR TITLE
Handle `lookup` issue when Prometheus is not present in Rancher cluster

### DIFF
--- a/charts/opscenter-features/templates/_helpers.tpl
+++ b/charts/opscenter-features/templates/_helpers.tpl
@@ -109,5 +109,5 @@ Image Templates
 {{- end }}
 
 {{- define "prometheus.mode" -}}
-{{- ternary "federated" "standalone" (and (has "Rancher" .Values.clusterMetadata.clusterManagers) (not (empty (lookup "monitoring.coreos.com/v1" "Prometheus" "cattle-monitoring-system" "rancher-monitoring-prometheus")))) -}}
+{{- ternary "federated" "standalone" (and (has "Rancher" .Values.clusterMetadata.clusterManagers) (not (and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") (lookup "monitoring.coreos.com/v1" "Prometheus" "cattle-monitoring-system" "rancher-monitoring-prometheus")))) -}}
 {{- end }}

--- a/charts/opscenter-features/templates/_helpers.tpl
+++ b/charts/opscenter-features/templates/_helpers.tpl
@@ -109,5 +109,5 @@ Image Templates
 {{- end }}
 
 {{- define "prometheus.mode" -}}
-{{- ternary "federated" "standalone" (and (has "Rancher" .Values.clusterMetadata.clusterManagers) (not (and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") (lookup "monitoring.coreos.com/v1" "Prometheus" "cattle-monitoring-system" "rancher-monitoring-prometheus")))) -}}
+{{- ternary "federated" "standalone" (and (has "Rancher" .Values.clusterMetadata.clusterManagers) (and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") (not (empty (lookup "monitoring.coreos.com/v1" "Prometheus" "cattle-monitoring-system" "rancher-monitoring-prometheus"))))) -}}
 {{- end }}


### PR DESCRIPTION
It fixes this error:
`executing "prometheus.mode" at <lookup "[monitoring.coreos.com/v1](http://monitoring.coreos.com/v1)" "Prometheus" "cattle-monitoring-system" "rancher-monitoring-prometheus">: error calling lookup: unable to get apiresource from unstructured: [monitoring.coreos.com/v1](http://monitoring.coreos.com/v1), Kind=Prometheus: the server could not find the requested resource`