### PR TITLE
Check the EAS resources only for metricserver readiness

### DIFF
--- a/charts/opscenter-features/templates/featuresets/opscenter-observability/monitoring/metrics-server.yaml
+++ b/charts/opscenter-features/templates/featuresets/opscenter-observability/monitoring/metrics-server.yaml
@@ -36,14 +36,6 @@ spec:
     - group: metrics.k8s.io
       version: v1beta1
       kind: PodMetrics
-    workloads:
-      - group: apps
-        version: v1
-        kind: Deployment
-        selector:
-          app.kubernetes.io/instance: metrics-server
-          app.kubernetes.io/managed-by: Helm
-          app.kubernetes.io/name: metrics-server
   chart:
     name: metrics-server
     namespace: monitoring


### PR DESCRIPTION
If some cluster has builtin metric-server. That will not have these labels