### PR TITLE
Add metrics port configuration

### DIFF
--- a/charts/ace/templates/platform/config.yaml
+++ b/charts/ace/templates/platform/config.yaml
@@ -95,7 +95,9 @@ stringData:
   {{- if (include "monitoring.agent" .) }}
 
     [metrics]
+    AGENT = {{ include "monitoring.agent" . }}
     ENABLED = true
+
   {{- end }}
 
     [cors]

--- a/charts/platform-api/templates/service.yaml
+++ b/charts/platform-api/templates/service.yaml
@@ -12,6 +12,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: metrics
   selector:
     {{- include "platform-api.selectorLabels" . | nindent 4 }}
 
@@ -33,6 +37,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: metrics
   # selector needed to create pods dns name
   selector:
     {{- include "platform-api.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Required by https://github.com/appscode-cloud/b3/pull/1354 in order to maintain compatibility with prometheus stack alongside otel stack