### PR TITLE
Use authorization credentials in ServiceMonitors

### DIFF
--- a/charts/acerproxy/templates/servicemonitor.yaml
+++ b/charts/acerproxy/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "acerproxy.fullname" . }}-token
+  name: {{ include "acerproxy.fullname" . }}-metrics-token
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "acerproxy.labels" . | nindent 4 }}
@@ -33,7 +33,7 @@ spec:
     authorization:
       type: Bearer
       credentials:
-        name: {{ include "acerproxy.fullname" . }}-token
+        name: {{ include "acerproxy.fullname" . }}-metrics-token
         key: token
     scheme: https
     tlsConfig:

--- a/charts/acerproxy/templates/servicemonitor.yaml
+++ b/charts/acerproxy/templates/servicemonitor.yaml
@@ -1,4 +1,15 @@
 {{- if eq "prometheus.io/operator" ( include "monitoring.agent" . ) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "acerproxy.fullname" . }}-monitoring-token
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "acerproxy.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "acerproxy.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -19,7 +30,11 @@ spec:
       {{- include "acerproxy.selectorLabels" . | nindent 6 }}
   endpoints:
   - port: api
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    authorization:
+      type: Bearer
+      credentials:
+        name: {{ include "acerproxy.fullname" . }}-monitoring-token
+        key: token
     scheme: https
     tlsConfig:
       ca:

--- a/charts/acerproxy/templates/servicemonitor.yaml
+++ b/charts/acerproxy/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "acerproxy.fullname" . }}-monitoring-token
+  name: {{ include "acerproxy.fullname" . }}-token
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "acerproxy.labels" . | nindent 4 }}
@@ -33,7 +33,7 @@ spec:
     authorization:
       type: Bearer
       credentials:
-        name: {{ include "acerproxy.fullname" . }}-monitoring-token
+        name: {{ include "acerproxy.fullname" . }}-token
         key: token
     scheme: https
     tlsConfig:

--- a/charts/catalog-manager/templates/servicemonitor.yaml
+++ b/charts/catalog-manager/templates/servicemonitor.yaml
@@ -1,4 +1,15 @@
 {{- if eq "prometheus.io/operator" ( include "monitoring.agent" . ) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "catalog-manager.fullname" . }}-monitoring-token
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "catalog-manager.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "catalog-manager.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -19,7 +30,11 @@ spec:
       {{- include "catalog-manager.selectorLabels" . | nindent 6 }}
   endpoints:
   - port: api
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    authorization:
+      type: Bearer
+      credentials:
+        name: {{ include "catalog-manager.fullname" . }}-monitoring-token
+        key: token
     scheme: https
     tlsConfig:
       ca:

--- a/charts/catalog-manager/templates/servicemonitor.yaml
+++ b/charts/catalog-manager/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "catalog-manager.fullname" . }}-token
+  name: {{ include "catalog-manager.fullname" . }}-metrics-token
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "catalog-manager.labels" . | nindent 4 }}
@@ -33,7 +33,7 @@ spec:
     authorization:
       type: Bearer
       credentials:
-        name: {{ include "catalog-manager.fullname" . }}-token
+        name: {{ include "catalog-manager.fullname" . }}-metrics-token
         key: token
     scheme: https
     tlsConfig:

--- a/charts/catalog-manager/templates/servicemonitor.yaml
+++ b/charts/catalog-manager/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "catalog-manager.fullname" . }}-monitoring-token
+  name: {{ include "catalog-manager.fullname" . }}-token
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "catalog-manager.labels" . | nindent 4 }}
@@ -33,7 +33,7 @@ spec:
     authorization:
       type: Bearer
       credentials:
-        name: {{ include "catalog-manager.fullname" . }}-monitoring-token
+        name: {{ include "catalog-manager.fullname" . }}-token
         key: token
     scheme: https
     tlsConfig:

--- a/charts/license-proxyserver/templates/servicemonitor.yaml
+++ b/charts/license-proxyserver/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "license-proxyserver.fullname" . }}-token
+  name: {{ include "license-proxyserver.fullname" . }}-metrics-token
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "license-proxyserver.labels" . | nindent 4 }}
@@ -33,7 +33,7 @@ spec:
     authorization:
       type: Bearer
       credentials:
-        name: {{ include "license-proxyserver.fullname" . }}-token
+        name: {{ include "license-proxyserver.fullname" . }}-metrics-token
         key: token
     scheme: https
     interval: 10s
@@ -50,7 +50,7 @@ spec:
     authorization:
       type: Bearer
       credentials:
-        name: {{ include "license-proxyserver.fullname" . }}-token
+        name: {{ include "license-proxyserver.fullname" . }}-metrics-token
         key: token
     scheme: http
     interval: 10s

--- a/charts/license-proxyserver/templates/servicemonitor.yaml
+++ b/charts/license-proxyserver/templates/servicemonitor.yaml
@@ -1,4 +1,15 @@
 {{- if eq "prometheus.io/operator" ( include "monitoring.agent" . ) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "license-proxyserver.fullname" . }}-monitoring-token
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "license-proxyserver.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "license-proxyserver.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -19,7 +30,11 @@ spec:
       {{- include "license-proxyserver.selectorLabels" . | nindent 6 }}
   endpoints:
   - port: api
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    authorization:
+      type: Bearer
+      credentials:
+        name: {{ include "license-proxyserver.fullname" . }}-monitoring-token
+        key: token
     scheme: https
     interval: 10s
     relabelings:
@@ -32,7 +47,11 @@ spec:
           key: ca.crt
       serverName: "{{ include "license-proxyserver.fullname" . }}.{{ .Release.Namespace }}.svc"
   - port: telemetry
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    authorization:
+      type: Bearer
+      credentials:
+        name: {{ include "license-proxyserver.fullname" . }}-monitoring-token
+        key: token
     scheme: http
     interval: 10s
 {{- end }}

--- a/charts/license-proxyserver/templates/servicemonitor.yaml
+++ b/charts/license-proxyserver/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "license-proxyserver.fullname" . }}-monitoring-token
+  name: {{ include "license-proxyserver.fullname" . }}-token
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "license-proxyserver.labels" . | nindent 4 }}
@@ -33,7 +33,7 @@ spec:
     authorization:
       type: Bearer
       credentials:
-        name: {{ include "license-proxyserver.fullname" . }}-monitoring-token
+        name: {{ include "license-proxyserver.fullname" . }}-token
         key: token
     scheme: https
     interval: 10s
@@ -50,7 +50,7 @@ spec:
     authorization:
       type: Bearer
       credentials:
-        name: {{ include "license-proxyserver.fullname" . }}-monitoring-token
+        name: {{ include "license-proxyserver.fullname" . }}-token
         key: token
     scheme: http
     interval: 10s

--- a/charts/service-backend/templates/servicemonitor.yaml
+++ b/charts/service-backend/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "service-backend.fullname" . }}-token
+  name: {{ include "service-backend.fullname" . }}-metrics-token
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "service-backend.labels" . | nindent 4 }}
@@ -33,7 +33,7 @@ spec:
     authorization:
       type: Bearer
       credentials:
-        name: {{ include "service-backend.fullname" . }}-token
+        name: {{ include "service-backend.fullname" . }}-metrics-token
         key: token
     scheme: https
     tlsConfig:

--- a/charts/service-backend/templates/servicemonitor.yaml
+++ b/charts/service-backend/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "service-backend.fullname" . }}-monitoring-token
+  name: {{ include "service-backend.fullname" . }}-token
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "service-backend.labels" . | nindent 4 }}
@@ -33,7 +33,7 @@ spec:
     authorization:
       type: Bearer
       credentials:
-        name: {{ include "service-backend.fullname" . }}-monitoring-token
+        name: {{ include "service-backend.fullname" . }}-token
         key: token
     scheme: https
     tlsConfig:

--- a/charts/service-backend/templates/servicemonitor.yaml
+++ b/charts/service-backend/templates/servicemonitor.yaml
@@ -1,4 +1,15 @@
 {{- if eq "prometheus.io/operator" ( include "monitoring.agent" . ) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "service-backend.fullname" . }}-monitoring-token
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "service-backend.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "service-backend.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -19,7 +30,11 @@ spec:
       {{- include "service-backend.selectorLabels" . | nindent 6 }}
   endpoints:
   - port: api
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    authorization:
+      type: Bearer
+      credentials:
+        name: {{ include "service-backend.fullname" . }}-monitoring-token
+        key: token
     scheme: https
     tlsConfig:
       ca:

--- a/charts/service-provider/templates/webhook-server/monitoring/servicemonitor.yaml
+++ b/charts/service-provider/templates/webhook-server/monitoring/servicemonitor.yaml
@@ -1,5 +1,16 @@
 {{- if or .Values.apiserver.enableMutatingWebhook .Values.apiserver.enableValidatingWebhook }}
 {{- if eq .Values.monitoring.agent "prometheus.io/operator" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "service-provider.fullname" . }}-monitoring-token
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "service-provider.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "service-provider.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -23,7 +34,11 @@ spec:
   endpoints:
   {{- if .Values.monitoring.operator }}
   - port: https
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    authorization:
+      type: Bearer
+      credentials:
+        name: {{ include "service-provider.fullname" . }}-monitoring-token
+        key: token
     path: /metrics
     scheme: https
     tlsConfig:

--- a/charts/service-provider/templates/webhook-server/monitoring/servicemonitor.yaml
+++ b/charts/service-provider/templates/webhook-server/monitoring/servicemonitor.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "service-provider.fullname" . }}-token
+  name: {{ include "service-provider.fullname" . }}-metrics-token
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "service-provider.labels" . | nindent 4 }}
@@ -37,7 +37,7 @@ spec:
     authorization:
       type: Bearer
       credentials:
-        name: {{ include "service-provider.fullname" . }}-token
+        name: {{ include "service-provider.fullname" . }}-metrics-token
         key: token
     path: /metrics
     scheme: https

--- a/charts/service-provider/templates/webhook-server/monitoring/servicemonitor.yaml
+++ b/charts/service-provider/templates/webhook-server/monitoring/servicemonitor.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "service-provider.fullname" . }}-monitoring-token
+  name: {{ include "service-provider.fullname" . }}-token
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "service-provider.labels" . | nindent 4 }}
@@ -37,7 +37,7 @@ spec:
     authorization:
       type: Bearer
       credentials:
-        name: {{ include "service-provider.fullname" . }}-monitoring-token
+        name: {{ include "service-provider.fullname" . }}-token
         key: token
     path: /metrics
     scheme: https


### PR DESCRIPTION
## Summary
- replace ServiceMonitor bearerTokenFile usage with authorization credentials bearer style
- add service-account-token Secret templates for affected charts
- align charts with Prometheus Operator restrictions on file-based bearer tokens

## Charts Updated
- acerproxy
- catalog-manager
- license-proxyserver
- service-backend
- service-provider

## Validation
- verified no bearerTokenFile remains in chart templates
- verified edited templates have no reported file errors