### PR TITLE
Add capi-capz featureset for Cluster API Azure

### DIFF
--- a/catalog/copy-images.sh
+++ b/catalog/copy-images.sh
@@ -106,6 +106,7 @@ $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/ga
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/gatekeeper-library:v2023.10.1 $IMAGE_REGISTRY/appscode-charts/gatekeeper-library:v2023.10.1
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/gatekeeper:3.13.3 $IMAGE_REGISTRY/appscode-charts/gatekeeper:3.13.3
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/gateway-api:v2025.3.14 $IMAGE_REGISTRY/appscode-charts/gateway-api:v2025.3.14
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/azure-credential-manager:v2026.4.16 $IMAGE_REGISTRY/appscode-charts/azure-credential-manager:v2026.4.16
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/gcp-credential-manager:v2026.3.11 $IMAGE_REGISTRY/appscode-charts/gcp-credential-manager:v2026.3.11
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/grafana-operator:v2026.3.30 $IMAGE_REGISTRY/appscode-charts/grafana-operator:v2026.3.30
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/hub-cluster-robot:v2026.2.16 $IMAGE_REGISTRY/appscode-charts/hub-cluster-robot:v2026.2.16
@@ -280,6 +281,7 @@ $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/ui
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/uibytebuildersdev-component-stash-presets:v0.12.0 $IMAGE_REGISTRY/appscode-charts/uibytebuildersdev-component-stash-presets:v0.12.0
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/uik8sappscodecom-featureset-capi-capa-editor:v0.32.0 $IMAGE_REGISTRY/appscode-charts/uik8sappscodecom-featureset-capi-capa-editor:v0.32.0
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/uik8sappscodecom-featureset-capi-capg-editor:v0.32.0 $IMAGE_REGISTRY/appscode-charts/uik8sappscodecom-featureset-capi-capg-editor:v0.32.0
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/uik8sappscodecom-featureset-capi-capz-editor:v0.32.0 $IMAGE_REGISTRY/appscode-charts/uik8sappscodecom-featureset-capi-capz-editor:v0.32.0
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/uik8sappscodecom-featureset-capi-core-editor:v0.32.0 $IMAGE_REGISTRY/appscode-charts/uik8sappscodecom-featureset-capi-core-editor:v0.32.0
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/uik8sappscodecom-featureset-crossplane-editor:v0.32.0 $IMAGE_REGISTRY/appscode-charts/uik8sappscodecom-featureset-crossplane-editor:v0.32.0
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/uik8sappscodecom-featureset-ocm-hub-editor:v0.32.0 $IMAGE_REGISTRY/appscode-charts/uik8sappscodecom-featureset-ocm-hub-editor:v0.32.0

--- a/catalog/export-images.sh
+++ b/catalog/export-images.sh
@@ -103,6 +103,7 @@ $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/gatekeeper-library:v2023.10.1 images/appscode-charts-gatekeeper-library-v2023.10.1.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/gatekeeper:3.13.3 images/appscode-charts-gatekeeper-3.13.3.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/gateway-api:v2025.3.14 images/appscode-charts-gateway-api-v2025.3.14.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/azure-credential-manager:v2026.4.16 images/appscode-charts-azure-credential-manager-v2026.4.16.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/gcp-credential-manager:v2026.3.11 images/appscode-charts-gcp-credential-manager-v2026.3.11.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/grafana-operator:v2026.3.30 images/appscode-charts-grafana-operator-v2026.3.30.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/hub-cluster-robot:v2026.2.16 images/appscode-charts-hub-cluster-robot-v2026.2.16.tar
@@ -277,6 +278,7 @@ $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/uibytebuildersdev-component-stash-presets:v0.12.0 images/appscode-charts-uibytebuildersdev-component-stash-presets-v0.12.0.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/uik8sappscodecom-featureset-capi-capa-editor:v0.32.0 images/appscode-charts-uik8sappscodecom-featureset-capi-capa-editor-v0.32.0.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/uik8sappscodecom-featureset-capi-capg-editor:v0.32.0 images/appscode-charts-uik8sappscodecom-featureset-capi-capg-editor-v0.32.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/uik8sappscodecom-featureset-capi-capz-editor:v0.32.0 images/appscode-charts-uik8sappscodecom-featureset-capi-capz-editor-v0.32.0.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/uik8sappscodecom-featureset-capi-core-editor:v0.32.0 images/appscode-charts-uik8sappscodecom-featureset-capi-core-editor-v0.32.0.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/uik8sappscodecom-featureset-crossplane-editor:v0.32.0 images/appscode-charts-uik8sappscodecom-featureset-crossplane-editor-v0.32.0.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode-charts/uik8sappscodecom-featureset-ocm-hub-editor:v0.32.0 images/appscode-charts-uik8sappscodecom-featureset-ocm-hub-editor-v0.32.0.tar

--- a/catalog/feature-charts.yaml
+++ b/catalog/feature-charts.yaml
@@ -1,5 +1,6 @@
 - ghcr.io/appscode-charts/aceshifter:v2026.4.30
 - ghcr.io/appscode-charts/aws-credential-manager:v2026.1.20
+- ghcr.io/appscode-charts/azure-credential-manager:v2026.4.16
 - ghcr.io/appscode-charts/aws-ebs-csi-driver:2.23.0
 - ghcr.io/appscode-charts/aws-load-balancer-controller:1.11.0
 - ghcr.io/appscode-charts/capa-vpc-peering-operator:v2023.12.11
@@ -84,6 +85,7 @@
 - ghcr.io/appscode-charts/topolvm:15.0.0
 - ghcr.io/appscode-charts/uik8sappscodecom-featureset-capi-capa-editor:v0.32.0
 - ghcr.io/appscode-charts/uik8sappscodecom-featureset-capi-capg-editor:v0.32.0
+- ghcr.io/appscode-charts/uik8sappscodecom-featureset-capi-capz-editor:v0.32.0
 - ghcr.io/appscode-charts/uik8sappscodecom-featureset-capi-core-editor:v0.32.0
 - ghcr.io/appscode-charts/uik8sappscodecom-featureset-crossplane-editor:v0.32.0
 - ghcr.io/appscode-charts/uik8sappscodecom-featureset-ocm-hub-editor:v0.32.0

--- a/catalog/import-images.sh
+++ b/catalog/import-images.sh
@@ -97,6 +97,7 @@ $CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-g
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-gatekeeper-library-v2023.10.1.tar $IMAGE_REGISTRY/appscode-charts/gatekeeper-library:v2023.10.1
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-gatekeeper-3.13.3.tar $IMAGE_REGISTRY/appscode-charts/gatekeeper:3.13.3
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-gateway-api-v2025.3.14.tar $IMAGE_REGISTRY/appscode-charts/gateway-api:v2025.3.14
+$CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-azure-credential-manager-v2026.4.16.tar $IMAGE_REGISTRY/appscode-charts/azure-credential-manager:v2026.4.16
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-gcp-credential-manager-v2026.3.11.tar $IMAGE_REGISTRY/appscode-charts/gcp-credential-manager:v2026.3.11
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-grafana-operator-v2026.3.30.tar $IMAGE_REGISTRY/appscode-charts/grafana-operator:v2026.3.30
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-hub-cluster-robot-v2026.2.16.tar $IMAGE_REGISTRY/appscode-charts/hub-cluster-robot:v2026.2.16
@@ -271,6 +272,7 @@ $CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-u
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-uibytebuildersdev-component-stash-presets-v0.12.0.tar $IMAGE_REGISTRY/appscode-charts/uibytebuildersdev-component-stash-presets:v0.12.0
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-uik8sappscodecom-featureset-capi-capa-editor-v0.32.0.tar $IMAGE_REGISTRY/appscode-charts/uik8sappscodecom-featureset-capi-capa-editor:v0.32.0
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-uik8sappscodecom-featureset-capi-capg-editor-v0.32.0.tar $IMAGE_REGISTRY/appscode-charts/uik8sappscodecom-featureset-capi-capg-editor:v0.32.0
+$CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-uik8sappscodecom-featureset-capi-capz-editor-v0.32.0.tar $IMAGE_REGISTRY/appscode-charts/uik8sappscodecom-featureset-capi-capz-editor:v0.32.0
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-uik8sappscodecom-featureset-capi-core-editor-v0.32.0.tar $IMAGE_REGISTRY/appscode-charts/uik8sappscodecom-featureset-capi-core-editor:v0.32.0
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-uik8sappscodecom-featureset-crossplane-editor-v0.32.0.tar $IMAGE_REGISTRY/appscode-charts/uik8sappscodecom-featureset-crossplane-editor:v0.32.0
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-charts-uik8sappscodecom-featureset-ocm-hub-editor-v0.32.0.tar $IMAGE_REGISTRY/appscode-charts/uik8sappscodecom-featureset-ocm-hub-editor:v0.32.0

--- a/catalog/import-into-k3s.sh
+++ b/catalog/import-into-k3s.sh
@@ -95,6 +95,7 @@ k3s ctr images import images/appscode-charts-gatekeeper-grafana-dashboards-v2023
 k3s ctr images import images/appscode-charts-gatekeeper-library-v2023.10.1.tar
 k3s ctr images import images/appscode-charts-gatekeeper-3.13.3.tar
 k3s ctr images import images/appscode-charts-gateway-api-v2025.3.14.tar
+k3s ctr images import images/appscode-charts-azure-credential-manager-v2026.4.16.tar
 k3s ctr images import images/appscode-charts-gcp-credential-manager-v2026.3.11.tar
 k3s ctr images import images/appscode-charts-grafana-operator-v2026.3.30.tar
 k3s ctr images import images/appscode-charts-hub-cluster-robot-v2026.2.16.tar
@@ -269,6 +270,7 @@ k3s ctr images import images/appscode-charts-uibytebuildersdev-component-service
 k3s ctr images import images/appscode-charts-uibytebuildersdev-component-stash-presets-v0.12.0.tar
 k3s ctr images import images/appscode-charts-uik8sappscodecom-featureset-capi-capa-editor-v0.32.0.tar
 k3s ctr images import images/appscode-charts-uik8sappscodecom-featureset-capi-capg-editor-v0.32.0.tar
+k3s ctr images import images/appscode-charts-uik8sappscodecom-featureset-capi-capz-editor-v0.32.0.tar
 k3s ctr images import images/appscode-charts-uik8sappscodecom-featureset-capi-core-editor-v0.32.0.tar
 k3s ctr images import images/appscode-charts-uik8sappscodecom-featureset-crossplane-editor-v0.32.0.tar
 k3s ctr images import images/appscode-charts-uik8sappscodecom-featureset-ocm-hub-editor-v0.32.0.tar

--- a/charts/opscenter-features/README.md
+++ b/charts/opscenter-features/README.md
@@ -73,6 +73,7 @@ The following table lists the configurable parameters of the `opscenter-features
 | helm.releases.aceshifter.version                                           |                                 | <code>"v2026.4.30"</code>                            |
 | helm.releases.appscode-otel-stack.version                                  |                                 | <code>"v2025.2.28"</code>                            |
 | helm.releases.aws-credential-manager.version                               |                                 | <code>"v2026.1.20"</code>                            |
+| helm.releases.azure-credential-manager.version                             |                                 | <code>"v2026.4.16"</code>                            |
 | helm.releases.gcp-credential-manager.version                               |                                 | <code>"v2026.3.11"</code>                            |
 | helm.releases.aws-ebs-csi-driver.version                                   |                                 | <code>"2.23.0"</code>                                |
 | helm.releases.aws-load-balancer-controller.version                         |                                 | <code>"1.11.0"</code>                                |

--- a/charts/opscenter-features/templates/featuresets/capi-capz/azure-credential-manager.yaml
+++ b/charts/opscenter-features/templates/featuresets/capi-capz/azure-credential-manager.yaml
@@ -1,0 +1,44 @@
+{{ $defaults := dict "registryFQDN" (include "registry.ghcr" $) }}
+
+{{ $vals := dig "azure-credential-manager" "values" (dict) .Values.helm.releases }}
+{{ $vals = mergeOverwrite $defaults $vals }}
+
+{{- if eq (include "distro.openshift" $) "true" }}
+{{ $vals = mergeOverwrite $vals (dict "distro" .Values.distro) }}
+{{- end }}
+
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: Feature
+metadata:
+  name: azure-credential-manager
+  labels:
+    app.kubernetes.io/part-of: capi-capz
+spec:
+  title: Azure Credential Manager
+  description: |
+    Azure Credential Manager
+  icons:
+    - src: https://cdn.appscode.com/k8s/icons/menu/cluster.svg
+      type: image/svg+xml
+  featureSet: capi-capz
+  featureBlock: azure-credential-manager
+  recommended: true
+  readinessChecks:
+    workloads:
+      - group: apps
+        version: v1
+        kind: Deployment
+        selector:
+          app.kubernetes.io/name: azure-credential-manager
+  chart:
+    name: azure-credential-manager
+    namespace: capz-system
+    createNamespace: {{ $.Values.helm.createNamespace }}
+    version: {{ dig "azure-credential-manager" "version" "" $.Values.helm.releases }}
+    sourceRef:
+      kind: HelmRepository
+      name: appscode-charts-oci
+      namespace: {{ .Release.Namespace }}
+{{- with $vals }}
+  {{- dict "values" . | toYaml | nindent 2 }}
+{{- end }}

--- a/charts/opscenter-features/templates/featuresets/capi-capz/featureset.yaml
+++ b/charts/opscenter-features/templates/featuresets/capi-capz/featureset.yaml
@@ -1,0 +1,20 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: FeatureSet
+metadata:
+  name: capi-capz
+spec:
+  title: Cluster API Azure (CAPZ)
+  description: |
+    Tools for CAPZ Clusters
+  icons:
+    - src: https://cdn.appscode.com/k8s/icons/menu/cluster.svg
+      type: image/svg+xml
+  recommended: false
+  chart:
+    name: uik8sappscodecom-featureset-capi-capz-editor
+    version: {{ .Chart.AppVersion }}
+    sourceRef:
+      apiGroup: source.toolkit.fluxcd.io
+      kind: HelmRepository
+      name: appscode-charts-oci
+      namespace: {{ .Release.Namespace }}

--- a/charts/opscenter-features/values.yaml
+++ b/charts/opscenter-features/values.yaml
@@ -60,6 +60,8 @@ helm:
       version: "v2025.2.28"
     aws-credential-manager:
       version: "v2026.1.20"
+    azure-credential-manager:
+      version: "v2026.4.16"
     gcp-credential-manager:
       version: "v2026.3.11"
     aws-ebs-csi-driver:


### PR DESCRIPTION
## Summary

Add support for Cluster API Azure (CAPZ) as a new featureset in opscenter-features, mirroring the existing capi-capg (CAPI GCP) pattern.

## Changes

- **New Templates**: Created `charts/opscenter-features/templates/featuresets/capi-capz/` with:
  - `featureset.yaml`: Declares the CAPZ FeatureSet CRD
  - `azure-credential-manager.yaml`: Declares azure-credential-manager Feature CRD

- **Configuration**: 
  - Added `azure-credential-manager` v2026.4.16 to `values.yaml`
  - Updated `README.md` with new configuration option

- **Catalog/Offline Support**:
  - Updated all 4 image management scripts: `copy-images.sh`, `export-images.sh`, `import-images.sh`, `import-into-k3s.sh`
  - Added entries to `catalog/feature-charts.yaml`

## Testing

✅ All changes validated:
- Chart templates render correctly with `helm template`
- OCI images verified as published to ghcr.io
- All Go unit tests pass
- Chart structure tests pass