### PR TITLE
Enable enableClusterRoles.audit in kube-ui-server featureset

### DIFF
--- a/charts/ace-installer-certified/templates/featuresets/opscenter-core/kube-ui-server.yaml
+++ b/charts/ace-installer-certified/templates/featuresets/opscenter-core/kube-ui-server.yaml
@@ -10,6 +10,7 @@ ace-user-roles:
   enableClusterRoles:
     ace: true
     appcatalog: true
+    audit: true
     catalog: true
     cert-manager: true
     kubedb-ui: true

--- a/charts/ace-installer/templates/featuresets/opscenter-core/kube-ui-server.yaml
+++ b/charts/ace-installer/templates/featuresets/opscenter-core/kube-ui-server.yaml
@@ -10,6 +10,7 @@ ace-user-roles:
   enableClusterRoles:
     ace: true
     appcatalog: true
+    audit: true
     catalog: true
     cert-manager: true
     kubedb-ui: true

--- a/charts/opscenter-features/templates/featuresets/opscenter-core/kube-ui-server.yaml
+++ b/charts/opscenter-features/templates/featuresets/opscenter-core/kube-ui-server.yaml
@@ -5,6 +5,7 @@ ace-user-roles:
   enableClusterRoles:
     ace: true
     appcatalog: true
+    audit: true
     catalog: true
     cert-manager: true
     kubedb-ui: true


### PR DESCRIPTION
## Summary
- Mirror `enableClusterRoles.license-proxyserver=true` with the new `enableClusterRoles.audit=true` in the kube-ui-server featureset templates (ace-installer, ace-installer-certified, opscenter-features)
- Grants ACE deployments the RBAC needed for the in-cluster audit token request fallback (see [go.bytebuilders.dev/audit#69](https://github.com/appscode-cloud/audit/pull/69))

## Test plan
- [ ] CI green