### PR TITLE
Fix 403 push failure in update-local-repo workflow

### DIFF
--- a/.github/workflows/update-local-repo.yml
+++ b/.github/workflows/update-local-repo.yml
@@ -18,6 +18,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          # Don't let actions/checkout install an http.extraheader carrying
+          # the auto-injected GITHUB_TOKEN — it would otherwise override the
+          # LGTM-app credentials embedded in the remote URL by the
+          # "Prepare git" step below, causing the push in trigger.sh to fail
+          # with a 403 ("Permission to appscode-cloud/installer.git denied to
+          # github-actions[bot]").
+          persist-credentials: false
 
       - name: Generate LGTM App token
         id: lgtm-app-token


### PR DESCRIPTION
## Summary

- Fixes the `update-local-repo` workflow which was failing at the `git push` step with `403 Permission to appscode-cloud/installer.git denied to github-actions[bot]` (see [run 26939671166](https://github.com/appscode-cloud/installer/actions/runs/26939671166/job/79477764631)).
- Root cause: `actions/checkout` defaults to `persist-credentials: true`, installing an `http.extraheader` with the auto-injected `GITHUB_TOKEN` (`github-actions[bot]`). That header outranks the LGTM-app token embedded in the remote URL by the "Prepare git" step, so the push in `hack/scripts/trigger.sh` authenticated as the wrong identity.
- Set `persist-credentials: false` on the checkout step so the URL-embedded LGTM token is actually used. Mirrors the existing fix in `kubeops.dev/installer`.

## Test plan

- [ ] Next push to `master` triggers the workflow and the `Update Local Helm repo` step pushes the autofixer branch successfully (no 403).