### PR TITLE
Fix regcache for registry 3.x config loading

### DIFF
--- a/charts/regcache/templates/configmap.yaml
+++ b/charts/regcache/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
       maintenance:
         uploadpurging:
           enabled: true
-          age: 168h
+          age: 72h
           interval: 24h
           dryrun: false
           dontcleanuptmpdir: false

--- a/charts/regcache/templates/configmap.yaml
+++ b/charts/regcache/templates/configmap.yaml
@@ -21,6 +21,10 @@ data:
       maintenance:
         uploadpurging:
           enabled: true
+          age: 168h
+          interval: 24h
+          dryrun: false
+          dontcleanuptmpdir: false
     http:
       addr: :5000
       headers:

--- a/charts/regcache/templates/deployment.yaml
+++ b/charts/regcache/templates/deployment.yaml
@@ -40,14 +40,13 @@ spec:
         {{- end }}
         image: "{{ include "regcache.image.registry" . }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args: ["serve", "/etc/docker/registry/config.yml"]
         ports:
         - name: registry
           containerPort: 5000
           protocol: TCP
-        env:
-        - name: REGISTRY_CONFIGURATION_PATH
-          value: /etc/docker/registry/config.yml
         {{- if .Values.username }}
+        env:
         - name: REGISTRY_PROXY_USERNAME
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
registry:3 ignores `REGISTRY_CONFIGURATION_PATH` and serves its built-in `/etc/distribution/config.yml`, so the pull-through proxy config never loaded — every pull returned `manifest unknown`.

- Pass the config path as an arg: `registry serve /etc/docker/registry/config.yml`
- Add `age`/`interval`/`dryrun`/`dontcleanuptmpdir` that 3.x requires when `uploadpurging` is enabled

Verified live: registry now logs "configured as a proxy cache to https://ghcr.io".