### PR TITLE
Add /observe perses route to ingress

### DIFF
--- a/charts/ace/templates/ingress/ingress-main.yaml
+++ b/charts/ace/templates/ingress/ingress-main.yaml
@@ -68,6 +68,15 @@ spec:
         path: /grafana
         pathType: Prefix
       {{- end }}
+      {{- if (index .Values "perses" "enabled") }}
+      - backend:
+          service:
+            name: {{ include "ace.fullname" . }}-perses
+            port:
+              number: 8080
+        path: /observe
+        pathType: Prefix
+      {{- end }}
       {{- if (index .Values "trickster" "enabled") }}
       - backend:
           service:


### PR DESCRIPTION
Mirrors the existing `/observe` → `-perses:8080` HTTPRoute rule (`route-main.yaml`) in the nginx ingress (`ingress-main.yaml`), guarded by `perses.enabled`, so the perses UI is reachable on ingress-based installs too.