### PR TITLE
Emit path-based NATS address for Gateway installs

### DIFF
--- a/charts/ace/templates/platform/config.yaml
+++ b/charts/ace/templates/platform/config.yaml
@@ -118,7 +118,7 @@ stringData:
     ADMIN_USER_CREDS = {{ .Values.settings.nats.mountPath }}/admin.creds
 
     INCLUSTER_ADDR = nats://{{ include "ace.fullname" . }}-nats.{{ .Release.Namespace }}.svc:4222
-    {{- if (and (index .Values "ingress-nginx" "enabled") (and .Values.nats.enabled (not .Values.nats.nats.externalAccess))) }}
+    {{- if (and (or (index .Values "ingress-nginx" "enabled") .Values.gateway.enabled) (and .Values.nats.enabled (not .Values.nats.nats.externalAccess))) }}
     EXTERNAL_ADDR = nats://{{ .Values.global.platform.host }}:4222
     WEBSOCKET_ADDR = wss://{{ .Values.global.platform.host }}/nats
     {{- else }}


### PR DESCRIPTION
The platform config (`charts/ace/templates/platform/config.yaml`) gated the path-based NATS endpoints behind `ingress-nginx` being enabled:

```
{{- if (and (index .Values "ingress-nginx" "enabled") (and .Values.nats.enabled (not .Values.nats.nats.externalAccess))) }}
EXTERNAL_ADDR  = nats://{{ .Values.global.platform.host }}:4222
WEBSOCKET_ADDR = wss://{{ .Values.global.platform.host }}/nats
{{- else }}
EXTERNAL_ADDR  = nats://nats.{{ .Values.global.platform.host }}:4222
WEBSOCKET_ADDR = wss://nats.{{ .Values.global.platform.host }}
{{- end }}
```

Gateway-based installs (`ingress-nginx.enabled=false`, `gateway.enabled=true`) fall into the `else` branch, which emits the subdomain form `wss://nats.<host>`.

## Problem

When `global.platform.host` is an IP (self-hosted, DNS-less), the `else` branch yields `wss://nats.<ip>` (e.g. `wss://nats.10.2.0.63`), which:

- is **unresolvable** — you cannot have a subdomain of an IP;
- is **not in the gateway cert SANs** (`ace-nats.ace.svc…`, `IP:<ip>`).

So the audit / site-info NATS client (via `b3` `NATS.ExternalAddresses()` → `kube-ui-server` extended API) gets `wss://nats.<ip>` back and can never connect:

```
failed to connect to event receiver  error="dial tcp: lookup nats.10.2.0.63: no such host"
```

The Gateway already provisions the matching route — an HTTPRoute with `PathPrefix: /nats` → `<release>-nats:443` — i.e. exactly the path-based endpoint the `if` branch emits.

## Fix

Take the path-based branch when **either** `ingress-nginx` **or** `gateway` is enabled. Gateway+IP installs then render `wss://<host>/nats`, which resolves (literal IP), TLS-validates (IP in cert SAN), and routes (existing `/nats` HTTPRoute).