### PR TITLE
Support hosted mode for gateway.domain helper

### DIFF
--- a/charts/service-gateway/templates/_helpers.tpl
+++ b/charts/service-gateway/templates/_helpers.tpl
@@ -62,10 +62,14 @@ The domain name used for the gateway.
 <clusterName>.<orgName / "ace">.<domain>
 */}}
 {{- define "gateway.domain" -}}
+{{- if eq (dig "mode" "" (.Values.gatewayClass.annotations | default dict)) "hosted" -}}
+{{- .Values.infra.host -}}
+{{- else -}}
 {{- $ns := trimSuffix "-gw" .Release.Namespace -}}
 {{- $useClusterName := or (eq $ns "ace") (eq .Values.infra.tenantSpreadPolicy "multi") -}}
 {{- $prefix := ternary (printf "%s.%s" .Values.clusterMetadata.name $ns) $ns $useClusterName -}}
 {{- printf "%s.%s" $prefix .Values.infra.host -}}
+{{- end -}}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
## Summary
- When `gatewayClass.annotations.mode` is `hosted`, `gateway.domain` (charts/service-gateway) now resolves to `infra.host` directly instead of the cluster/namespace-prefixed name.
- All existing callers (`gw.yaml`, `gwclass.yaml`, `gateway-dns.yaml`, `certificate.yaml`) pick this up automatically via the shared helper.

## Test plan
- [x] `helm template` with default values renders cleanly
- [x] `helm template --show-only templates/gateway-tls/certificate.yaml` — default produces `tbd.ace.chart-example.local`
- [x] Same, with `--set gatewayClass.annotations.mode=hosted --set infra.host=example.com` — produces `example.com` exactly