### PR TITLE
Add extra SANs for hosted gateway TLS certificate

### DIFF
--- a/charts/ace/templates/gateway/route-main.yaml
+++ b/charts/ace/templates/gateway/route-main.yaml
@@ -22,6 +22,9 @@ spec:
     {{- if eq (include "ace.gateway.migrationActive" .) "true" }}
     - {{ include "ace.gateway.fqdn" . }}
     {{- end }}
+    {{- if eq .Values.global.platform.deploymentType "Hosted" }}
+    - "api.{{ .Values.global.platform.host }}"
+    {{- end }}
   {{- end }}
   rules:
   - matches:

--- a/charts/ace/templates/gateway/route-main.yaml
+++ b/charts/ace/templates/gateway/route-main.yaml
@@ -22,7 +22,7 @@ spec:
     {{- if eq (include "ace.gateway.migrationActive" .) "true" }}
     - {{ include "ace.gateway.fqdn" . }}
     {{- end }}
-    {{- if eq .Values.global.platform.deploymentType "Hosted" }}
+    {{- if and (eq .Values.global.platform.deploymentType "Hosted") (eq .Values.global.platform.host "appscode.com") }}
     - "api.{{ .Values.global.platform.host }}"
     {{- end }}
   {{- end }}

--- a/charts/opscenter-features/README.md
+++ b/charts/opscenter-features/README.md
@@ -157,10 +157,10 @@ The following table lists the configurable parameters of the `opscenter-features
 | helm.releases.cluster-manager-hub.version                               |                                 | <code>"v2026.2.16"</code>                  |
 | helm.releases.cluster-manager-spoke.version                             |                                 | <code>"v2026.2.16"</code>                  |
 | helm.releases.managed-serviceaccount-manager.version                    |                                 | <code>"v2026.2.16"</code>                  |
-| helm.releases.cluster-proxy-manager.version                             |                                 | <code>"v2026.2.16"</code>                  |
-| helm.releases.cluster-gateway-manager.version                           |                                 | <code>"v2026.2.16"</code>                  |
+| helm.releases.cluster-proxy-manager.version                             |                                 | <code>"v2026.6.26"</code>                  |
+| helm.releases.cluster-gateway-manager.version                           |                                 | <code>"v2026.6.26"</code>                  |
 | helm.releases.cluster-auth-manager.version                              |                                 | <code>"v2026.2.16"</code>                  |
-| helm.releases.cluster-profile-manager.version                           |                                 | <code>"v2026.2.16"</code>                  |
+| helm.releases.cluster-profile-manager.version                           |                                 | <code>"v2026.6.26"</code>                  |
 | helm.releases.hub-cluster-robot.version                                 |                                 | <code>"v2026.2.16"</code>                  |
 | helm.releases.fluxcd-manager.version                                    |                                 | <code>"v2026.2.16"</code>                  |
 | helm.releases.license-proxyserver-manager.version                       |                                 | <code>"v2026.2.16"</code>                  |

--- a/charts/opscenter-features/values.yaml
+++ b/charts/opscenter-features/values.yaml
@@ -231,13 +231,13 @@ helm:
     managed-serviceaccount-manager:
       version: "v2026.2.16"
     cluster-proxy-manager:
-      version: "v2026.2.16"
+      version: "v2026.6.26"
     cluster-gateway-manager:
-      version: "v2026.2.16"
+      version: "v2026.6.26"
     cluster-auth-manager:
       version: "v2026.2.16"
     cluster-profile-manager:
-      version: "v2026.2.16"
+      version: "v2026.6.26"
     hub-cluster-robot:
       version: "v2026.2.16"
     fluxcd-manager:

--- a/charts/service-gateway/templates/gateway-tls/certificate.yaml
+++ b/charts/service-gateway/templates/gateway-tls/certificate.yaml
@@ -31,9 +31,10 @@ spec:
   {{- if eq .Values.infra.hostType "domain" }}
   dnsNames:
     - {{ include "gateway.domain" . }}
-    {{- if and (eq (dig "mode" "" (.Values.gatewayClass.annotations | default dict)) "hosted") (eq .Values.global.platform.host "appscode.com") }}
-    - "nats.{{ .Values.global.platform.host }}"
-    - "api.{{ .Values.global.platform.host }}"
+    {{- $platformHost := dig "platform" "host" "" (.Values.global | default dict) }}
+    {{- if and (eq (dig "mode" "" (.Values.gatewayClass.annotations | default dict)) "hosted") (eq $platformHost "appscode.com") }}
+    - "nats.{{ $platformHost }}"
+    - "api.{{ $platformHost }}"
     - "api.byte.builders"
     {{- end }}
   commonName: {{ include "gateway.domain" . }}

--- a/charts/service-gateway/templates/gateway-tls/certificate.yaml
+++ b/charts/service-gateway/templates/gateway-tls/certificate.yaml
@@ -31,10 +31,9 @@ spec:
   {{- if eq .Values.infra.hostType "domain" }}
   dnsNames:
     - {{ include "gateway.domain" . }}
-    {{- $platformHost := dig "platform" "host" "" (.Values.global | default dict) }}
-    {{- if and (eq (dig "mode" "" (.Values.gatewayClass.annotations | default dict)) "hosted") (eq $platformHost "appscode.com") }}
-    - "nats.{{ $platformHost }}"
-    - "api.{{ $platformHost }}"
+    {{- if and (eq (dig "mode" "" (.Values.gatewayClass.annotations | default dict)) "hosted") (eq .Values.infra.host "appscode.com") }}
+    - "nats.{{ .Values.infra.host }}"
+    - "api.{{ .Values.infra.host }}"
     - "api.byte.builders"
     {{- end }}
   commonName: {{ include "gateway.domain" . }}

--- a/charts/service-gateway/templates/gateway-tls/certificate.yaml
+++ b/charts/service-gateway/templates/gateway-tls/certificate.yaml
@@ -31,6 +31,11 @@ spec:
   {{- if eq .Values.infra.hostType "domain" }}
   dnsNames:
     - {{ include "gateway.domain" . }}
+    {{- if and (eq (dig "mode" "" (.Values.gatewayClass.annotations | default dict)) "hosted") (eq .Values.global.platform.host "appscode.com") }}
+    - "nats.{{ .Values.global.platform.host }}"
+    - "api.{{ .Values.global.platform.host }}"
+    - "api.byte.builders"
+    {{- end }}
   commonName: {{ include "gateway.domain" . }}
   {{- end }}
   usages:

--- a/charts/service-gateway/templates/gateway-tls/issuer.yaml
+++ b/charts/service-gateway/templates/gateway-tls/issuer.yaml
@@ -30,7 +30,45 @@ spec:
       name: {{ include "tenant.name" . }}-gw-acme-cred
     solvers:
     # An empty 'selector' means that this solver matches all domains
-    {{- if (eq .Values.infra.tls.acme.solver "Ingress") }}
+    {{- if eq (dig "mode" "" (.Values.gatewayClass.annotations | default dict)) "hosted" }}
+    - selector: {}
+      dns01:
+        {{- if eq .Values.infra.dns.provider "cloudflare" }}
+        cloudflare:
+          apiTokenSecretRef:
+            name: {{ include "tenant.name" . }}-gw-dns-cred
+            key: CF_API_TOKEN
+        {{- end }}
+        {{- if eq .Values.infra.dns.provider "route53" }}
+        route53:
+          region: {{ .Values.infra.dns.auth.route53.AWS_REGION }}
+          accessKeyIDSecretRef:
+            name: {{ include "tenant.name" . }}-gw-dns-cred
+            key: AWS_ACCESS_KEY_ID
+          secretAccessKeySecretRef:
+            name: {{ include "tenant.name" . }}-gw-dns-cred
+            key: AWS_SECRET_ACCESS_KEY
+        {{- end }}
+        {{- if eq .Values.infra.dns.provider "cloudDNS" }}
+        cloudDNS:
+          project: {{ .Values.infra.dns.auth.cloudDNS.GOOGLE_PROJECT_ID }}
+          serviceAccountSecretRef:
+            name: {{ include "tenant.name" . }}-gw-dns-cred
+            key: GOOGLE_SERVICE_ACCOUNT_JSON_KEY
+        {{- end }}
+        {{- if eq .Values.infra.dns.provider "azureDNS" }}
+        azureDNS:
+          clientID: {{ .Values.infra.dns.auth.azureDNS.servicePrincipalAppID }}
+          clientSecretSecretRef:
+            name: {{ include "tenant.name" . }}-gw-dns-cred
+            key: SERVICE_PRINCIPAL_PASSWORD
+          subscriptionID: {{ .Values.infra.dns.auth.azureDNS.subscriptionID }}
+          tenantID: {{ .Values.infra.dns.auth.azureDNS.tenantID }}
+          resourceGroupName: {{ .Values.infra.dns.auth.azureDNS.resourceGroupName }}
+          hostedZoneName: {{ .Values.infra.dns.auth.azureDNS.hostedZoneName }}
+          environment: {{ .Values.infra.dns.auth.azureDNS.environment | default "AzurePublicCloud" }}
+        {{- end }}
+    {{- else if (eq .Values.infra.tls.acme.solver "Ingress") }}
     - selector: {}
       http01:
         ingress:

--- a/charts/service-gateway/templates/gateway/gwclass.yaml
+++ b/charts/service-gateway/templates/gateway/gwclass.yaml
@@ -71,13 +71,17 @@ spec:
                     {{- end }}
 
       envoyService:
+        {{- $extraDomains := list }}
+        {{- if and (eq (dig "mode" "" (.Values.gatewayClass.annotations | default dict)) "hosted") (eq .Values.infra.host "appscode.com") }}
+        {{- $extraDomains = list (printf "nats.%s" .Values.infra.host) (printf "api.%s" .Values.infra.host) "api.byte.builders" }}
+        {{- end }}
         {{- if or .Values.envoy.service.annotations (eq .Values.infra.hostType "domain") }}
         annotations:
           {{- with .Values.envoy.service.annotations }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- if eq .Values.infra.hostType "domain" }}
-          external-dns.alpha.kubernetes.io/hostname: {{ include "gateway.domain" . }}
+          external-dns.alpha.kubernetes.io/hostname: {{ prepend $extraDomains (include "gateway.domain" .) | join "," }}
           {{- end }}
         {{- end }}
         externalTrafficPolicy: {{ .Values.envoy.service.externalTrafficPolicy }}


### PR DESCRIPTION
- Add `nats.<host>`, `api.<host>`, and `api.byte.builders` to the gateway TLS certificate's `dnsNames` when the gateway class is `hosted` and platform host is `appscode.com`.
- Mirror those extra subdomains into the `external-dns.alpha.kubernetes.io/hostname` annotation on the envoy Service, so ExternalDNS actually creates the `api.appscode.com` DNS record (was routable/TLS'd but unresolvable).
- Add `api.<host>` to the `ace` chart's gateway `HTTPRoute` hostnames, scoped to `deploymentType: Hosted` and `host: appscode.com` only.