### PR TITLE
Propagate chart version to regcache dependency in ace-installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,8 @@ contents-%:
 	  yq -y --indentless -i '.dependencies |= map(select(.name == "$*").version="$(CHART_VERSION)")' ./charts/ace/Chart.yaml; \
 	  yq -y --indentless -i '.dependencies |= map(select(.name == "$*").version="$(CHART_VERSION)")' ./charts/acaas/Chart.yaml; \
 	  yq -y --indentless -i '.dependencies |= map(select(.name == "$*").version="$(CHART_VERSION)")' ./charts/platform-opscenter/Chart.yaml; \
+	  yq -y --indentless -i '.dependencies |= map(select(.name == "$*").version="$(CHART_VERSION)")' ./charts/ace-installer/Chart.yaml; \
+	  yq -y --indentless -i '.dependencies |= map(select(.name == "$*").version="$(CHART_VERSION)")' ./charts/ace-installer-certified/Chart.yaml; \
 	fi
 	@if [ -n "$(APP_VERSION)" ]; then \
 		yq -y --indentless -i '.appVersion="$(APP_VERSION)"' ./charts/$*/Chart.yaml; \


### PR DESCRIPTION
The \`v2026.7.10\` release ([failing job](https://github.com/appscode-cloud/CHANGELOG/actions/runs/29208190850/job/86691209754)) failed with:

```
Error: can't get a valid version for 1 subchart(s): "regcache"
(repository "file://../regcache", version "v2026.6.19").
Make sure a matching chart version exists in the repo, or change the version constraint in Chart.yaml
```

## Root cause

The `contents-%` target in the `Makefile` bumps a subchart’s version and propagates it into the matching dependency constraint of parent charts — but only `ace`, `acaas`, and `platform-opscenter`:

```make
yq ... .dependencies |= map(select(.name == "$*").version="$(CHART_VERSION)") ./charts/ace/Chart.yaml
yq ... ./charts/acaas/Chart.yaml
yq ... ./charts/platform-opscenter/Chart.yaml
```

`regcache` is a dependency **only** of `ace-installer` and `ace-installer-certified` (none of the three listed charts use it). So when `make update-charts` bumps `regcache` to the new release version, the `ace-installer` dependency stays pinned to the previous version, and `helm dependency update charts/ace-installer` can no longer find it.

## Fix

Add `ace-installer` and `ace-installer-certified` to the propagation list so their `regcache` dependency constraint is bumped alongside the chart. (The `map(select(.name == "$*"))` is a no-op for charts that do not depend on `$*`, so the existing entries stay safe.)