### PR TITLE
Add make refresh target and require it before opening a PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Sibling pattern to `kubeops.dev/installer`, `kubevault.dev/installer`, etc. — 
 - `make gen-values-schema` — regenerate `values.openapiv3_schema.yaml`.
 - `make gen-chart-doc` — per-chart `README.md`.
 - `make update-charts` — refresh chart metadata.
+- `make refresh` — `gen update-catalog fmt`. **ALWAYS run this before opening a PR** so generated files are current.
 - `make fmt`, `make lint`, `make unit-tests` / `make test` — standard.
 - `make ct` — chart-testing.
 - `make verify` — module-tidy verification.

--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,9 @@ manifests: gen-crds gen-schema patch-schema gen-chart-doc
 .PHONY: gen
 gen: codegen manifests
 
+.PHONY: refresh
+refresh: gen update-catalog fmt
+
 BIN_DIR ?= $(CURDIR)/bin/$(OS)_$(ARCH)
 
 .PHONY: install-image-packer


### PR DESCRIPTION
Adds a `refresh` Makefile target that chains `gen`, `update-catalog`, and `fmt`, and documents in AGENTS.md that it should always be run before opening a PR so generated files stay current.

```makefile
.PHONY: refresh
refresh: gen update-catalog fmt
```