### PR TITLE
Hide Users page in kubedb-ui-presets; Use billing ui 2.4.10

### DIFF
--- a/catalog/imagelist.yaml
+++ b/catalog/imagelist.yaml
@@ -5,7 +5,7 @@
 - ghcr.io/appscode/acerproxy:v0.2.0
 - ghcr.io/appscode/aceshifter:v0.0.3
 - ghcr.io/appscode/b3:v2026.7.10
-- ghcr.io/appscode/billing-ui:2.4.0
+- ghcr.io/appscode/billing-ui:2.4.10
 - ghcr.io/appscode/catalog-manager:v0.13.0
 - ghcr.io/appscode/cert-manager-webhook-ace:v0.0.2
 - ghcr.io/appscode/cloudflare-dns-proxy:v0.0.5

--- a/charts/billing-ui/Chart.yaml
+++ b/charts/billing-ui/Chart.yaml
@@ -3,7 +3,7 @@ name: billing-ui
 description: A Helm chart for Kubernetes
 type: application
 version: v2026.7.10
-appVersion: 2.4.0
+appVersion: 2.4.10
 home: https://github.com/appscode-cloud
 icon: https://cdn.appscode.com/images/products/bytebuilders/icons/android-icon-192x192.png
 sources:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/druid.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/druid.yaml
@@ -71,7 +71,7 @@ spec:
       info: {}
       insight: false
       show: true
-    show: true
+    show: false
   - name: Operations
     sections:
     - blocks:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/elasticsearch.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/elasticsearch.yaml
@@ -74,7 +74,7 @@ spec:
       info: {}
       insight: false
       show: true
-    show: true
+    show: false
   - name: Operations
     sections:
     - blocks:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/hazelcast.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/hazelcast.yaml
@@ -65,7 +65,7 @@ spec:
       info: {}
       insight: false
       show: true
-    show: true
+    show: false
   - name: Operations
     sections:
     - blocks:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/kafka.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/kafka.yaml
@@ -65,7 +65,7 @@ spec:
       info: {}
       insight: false
       show: true
-    show: true
+    show: false
   - name: Operations
     sections:
     - blocks:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/mariadb.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/mariadb.yaml
@@ -74,7 +74,7 @@ spec:
       info: {}
       insight: false
       show: true
-    show: true
+    show: false
   - name: Operations
     sections:
     - blocks:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/memcached.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/memcached.yaml
@@ -84,15 +84,6 @@ spec:
       insight: false
       show: true
     show: false
-  - name: Monitoring
-    sections:
-    - blocks:
-        Prometheus: true
-        Service Monitors: true
-      info: {}
-      insight: false
-      show: true
-    show: true
   - name: Security
     sections:
     - blocks:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/mongodb.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/mongodb.yaml
@@ -74,7 +74,7 @@ spec:
       info: {}
       insight: false
       show: true
-    show: true
+    show: false
   - name: Operations
     sections:
     - blocks:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/mysql.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/mysql.yaml
@@ -74,7 +74,7 @@ spec:
       info: {}
       insight: false
       show: true
-    show: true
+    show: false
   - name: Operations
     sections:
     - blocks:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/oracle.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/oracle.yaml
@@ -54,7 +54,7 @@ spec:
       info: {}
       insight: false
       show: true
-    show: true
+    show: false
   - name: Insights
     sections:
     - blocks:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/perconaxtradb.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/perconaxtradb.yaml
@@ -62,7 +62,7 @@ spec:
       info: {}
       insight: false
       show: true
-    show: true
+    show: false
   - name: Operations
     sections:
     - blocks:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/pgbouncer.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/pgbouncer.yaml
@@ -59,7 +59,7 @@ spec:
       info: {}
       insight: false
       show: true
-    show: true
+    show: false
   - name: Operations
     sections:
     - blocks:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/postgres.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/postgres.yaml
@@ -76,7 +76,7 @@ spec:
       info: {}
       insight: false
       show: true
-    show: true
+    show: false
   - name: Operations
     sections:
     - blocks:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/rabbitmq.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/rabbitmq.yaml
@@ -57,7 +57,7 @@ spec:
       info: {}
       insight: false
       show: true
-    show: true
+    show: false
   - name: Insights
     sections:
     - blocks:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/redis.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/redis.yaml
@@ -74,7 +74,7 @@ spec:
       info: {}
       insight: false
       show: true
-    show: true
+    show: false
   - name: Operations
     sections:
     - blocks:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/singlestore.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/singlestore.yaml
@@ -71,7 +71,7 @@ spec:
       info: {}
       insight: false
       show: true
-    show: true
+    show: false
   - name: Operations
     sections:
     - blocks:

--- a/charts/kubedb-ui-presets/templates/resourceoutlinefilters/solr.yaml
+++ b/charts/kubedb-ui-presets/templates/resourceoutlinefilters/solr.yaml
@@ -71,7 +71,7 @@ spec:
       info: {}
       insight: false
       show: true
-    show: true
+    show: false
   - name: Operations
     sections:
     - blocks:


### PR DESCRIPTION
Set page-level `show: false` on the `Users` page in the 15 ResourceOutlineFilters that define one (druid, elasticsearch, hazelcast, kafka, mariadb, mongodb, mysql, oracle, perconaxtradb, pgbouncer, postgres, rabbitmq, redis, singlestore, solr), matching how `Security` and `Manifests` are already disabled. Section-level `show` and blocks are untouched. The other 15 databases never had a Users page, so they were already hidden by the default-hidden rule.

Also removes the `Monitoring` page from `memcached.yaml` — it was the only filter of 30 defining one, so the Monitoring tab rendered for Memcached and nowhere else. Monitoring stays reachable via the Insights/Dashboards blocks and the Monitoring action.

Page totals after this change:

| Page | show=true | show=false |
|---|---|---|
| Overview | 30 | 0 |
| Operations | 29 | 0 |
| Insights | 25 | 0 |
| Backup | 17 | 0 |
| Users | 0 | 15 |
| Security | 0 | 30 |
| Manifests | 0 | 30 |
| Backup (Legacy) | 0 | 9 |

No individual block is set to `false` in any filter; visibility is decided entirely at page level.