### PR TITLE
Turn off Redis AOF on the ace-cache

### DIFF
--- a/charts/ace/templates/cache/cache-config.yaml
+++ b/charts/ace/templates/cache/cache-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ace.fullname" . }}-cache-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ace.offshootLabels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: {{ include "ace.fullname" . }}-cache
+    app.kubernetes.io/managed-by: kubedb.com
+    app.kubernetes.io/name: redises.kubedb.com
+type: Opaque
+stringData:
+  redis.conf: |
+    appendonly no

--- a/charts/ace/templates/cache/cache.yaml
+++ b/charts/ace/templates/cache/cache.yaml
@@ -50,6 +50,8 @@ spec:
         runAsGroup: {{ .Values.securityContext.runAsUser }}
     {{- end }}
   deletionPolicy: {{ .Values.settings.cache.deletionPolicy }}
+  configuration:
+    secretName: {{ include "ace.fullname" . }}-cache-config
   authSecret:
     name: {{ include "ace.fullname" . }}-cache-auth
     externallyManaged: true


### PR DESCRIPTION
Renders an `ace-cache-config` secret holding `redis.conf: appendonly no` and wires it into the `ace-cache` Redis via `spec.configuration.secretName`, mirroring how `ace-db-config` is wired in `templates/db/`.

Fresh installs get AOF off at DB creation. For existing installs the config is applied by a `Reconfigure` RedisOpsRequest from the b3 upgrade job (appscode-cloud/b3#1608).

Verified with `helm template ace charts/ace -n ace` — the secret renders and the Redis carries `configuration.secretName: ace-cache-config`.