### PR TITLE
Scope the billing service account helper to the chart

### DIFF
--- a/charts/billing/templates/_helpers.tpl
+++ b/charts/billing/templates/_helpers.tpl
@@ -53,7 +53,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "appscode.serviceAccountName" -}}
+{{- define "billing.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
 {{- default (include "billing.fullname" .) .Values.serviceAccount.name }}
 {{- else }}

--- a/charts/billing/templates/aggregator/cronjob.yaml
+++ b/charts/billing/templates/aggregator/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
       template:
         spec:
           {{- include "appscode.imagePullSecrets" . | nindent 10 }}
-          serviceAccountName: {{ include "appscode.serviceAccountName" . }}
+          serviceAccountName: {{ include "billing.serviceAccountName" . }}
           {{- if eq "true" ( include "distro.openshift" . ) }}
           securityContext:
             {{- toYaml (omit .Values.podSecurityContext "runAsUser" "runAsGroup" "fsGroup" "supplementalGroups") | nindent 12 }}

--- a/charts/billing/templates/aggregator/statefulset.yaml
+++ b/charts/billing/templates/aggregator/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
         {{- include "billing.selectorLabels" . | nindent 8 }}
     spec:
       {{- include "appscode.imagePullSecrets" . | nindent 6 }}
-      serviceAccountName: {{ include "appscode.serviceAccountName" . }}
+      serviceAccountName: {{ include "billing.serviceAccountName" . }}
       {{- if eq "true" ( include "distro.openshift" . ) }}
       securityContext:
         {{- toYaml (omit .Values.podSecurityContext "runAsUser" "runAsGroup" "fsGroup" "supplementalGroups") | nindent 8 }}

--- a/charts/billing/templates/processor/statefulset.yaml
+++ b/charts/billing/templates/processor/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
         {{- include "billing.selectorLabels" . | nindent 8 }}
     spec:
       {{- include "appscode.imagePullSecrets" . | nindent 6 }}
-      serviceAccountName: {{ include "appscode.serviceAccountName" . }}
+      serviceAccountName: {{ include "billing.serviceAccountName" . }}
       {{- if eq "true" ( include "distro.openshift" . ) }}
       securityContext:
         {{- toYaml (omit .Values.podSecurityContext "runAsUser" "runAsGroup" "fsGroup" "supplementalGroups") | nindent 8 }}

--- a/charts/billing/templates/rbac/rbac.yaml
+++ b/charts/billing/templates/rbac/rbac.yaml
@@ -63,7 +63,7 @@ roleRef:
   name: appscode:license-checker
 subjects:
 - kind: ServiceAccount
-  name: {{ include "appscode.serviceAccountName" . }}
+  name: {{ include "billing.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 
 ---
@@ -102,7 +102,7 @@ roleRef:
   name: appscode:license-reader
 subjects:
 - kind: ServiceAccount
-  name: {{ include "appscode.serviceAccountName" . }}
+  name: {{ include "billing.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 
 ---
@@ -150,5 +150,5 @@ roleRef:
   name: {{ include "billing.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "appscode.serviceAccountName" . }}
+  name: {{ include "billing.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/billing/templates/rbac/serviceaccount.yaml
+++ b/charts/billing/templates/rbac/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "appscode.serviceAccountName" . }}
+  name: {{ include "billing.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "billing.labels" . | nindent 4 }}


### PR DESCRIPTION
Installing the acaas umbrella failed with

  ServiceAccount "default" in namespace "ace" exists and cannot be
  imported into the current release: invalid ownership metadata

Helm keeps template definitions in one global namespace, and every acaas subchart defines appscode.serviceAccountName. billing-ui, marketplace-api, platform-links and website all define it as

  {{- default "default" .Values.serviceAccount.name }}

so once any of them is enabled its body wins over billing's and the name collapses to "default", which makes the chart try to adopt the namespace's built-in service account. The collision was invisible while billing's own body was identical; it only surfaced once the name started feeding a ServiceAccount object and the role bindings.

Rename the define to billing.serviceAccountName, matching the chart-scoped billing.fullname and billing.labels, and update the six call sites. With the acaas values that reproduced the failure, billing now renders acaas-billing for the service account, all three pod specs and all three role bindings.