### PR TITLE
Set CA_CERT_PATH only when an object storage CA cert is provided

### DIFF
--- a/charts/ace/templates/platform/config.yaml
+++ b/charts/ace/templates/platform/config.yaml
@@ -139,7 +139,9 @@ stringData:
     BUCKET_ENDPOINT = {{ .Values.global.infra.objstore.endpoint }}
     BUCKET_REGION   = {{ .Values.global.infra.objstore.region }}
     BUCKET_PREFIX   = {{ .Values.global.infra.objstore.prefix }}
-    CA_CERT_PATH  =   /data/credentials/ca.crt
+    {{- if and .Values.global.infra.objstore.s3 .Values.global.infra.objstore.s3.CA_CERT_DATA }}
+    CA_CERT_PATH    = /data/credentials/ca.crt
+    {{- end }}
 
     [picture]
     DISABLE_GRAVATAR        = false


### PR DESCRIPTION
`CA_CERT_PATH` was emitted unconditionally in the platform config, pointing b3 at `/data/credentials/ca.crt` whether or not `objstore.s3.CA_CERT_DATA` was ever set.

That is harmless when the file is absent, but not when it exists and is empty — which is the case on any installation that passed through charts v2026.5–v2026.6. Commit 88effb31 made `objstore-cred.yaml` always render `ca.crt: ""`, writing an empty key into the secret. 802ccc55 restored the `with` guard, so the key left the manifest, but Helm cannot delete it: the secret's stored `last-applied-configuration` is from v2026.4.30 and never contained `ca.crt`, so it was never in the removal set. The empty key is orphaned in the live object.

b3 then reads a zero-byte file into a non-nil slice and blobfs rejects every bucket operation with `failed to parse CA certificate`, breaking avatars, attachments, LFS and client-org deletion.

`objstore-cred.yaml` needs no change — its guard is already correct as of 802ccc55, which is an ancestor of v2026.7.10. Not emitting the path is what makes the orphaned key inert.

Verified with `helm template` against a live HelmRelease's values:
- no `CA_CERT_DATA` → key absent
- `CA_CERT_DATA` set → `CA_CERT_PATH = /data/credentials/ca.crt`
- `provider=gcs`, `s3=null` → key absent, no nil dereference

Companion fix: appscode-cloud/b3#1619.
