### PR TITLE
Harden the appscode.com serving path against intermittent 5xx

### DIFF
--- a/charts/ace/templates/gateway/backend-traffic-policy.yaml
+++ b/charts/ace/templates/gateway/backend-traffic-policy.yaml
@@ -1,0 +1,34 @@
+{{ if (index .Values "gateway" "enabled") }}
+
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: {{ include "ace.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: {{ include "ace.fullname" . }}
+  retry:
+    numRetries: 2
+    retryOn:
+      # Only triggers where the backend provably never saw the request, so retrying a
+      # non-idempotent POST (/api/v1/register, /api/v1/license/issue) stays safe.
+      triggers:
+      - connect-failure
+      - refused-stream
+      - reset-before-request
+    perRetry:
+      backOff:
+        baseInterval: 100ms
+        maxInterval: 1s
+  healthCheck:
+    passive:
+      # Eject a replica that is failing but still listed in the endpoints, which readiness
+      # alone takes up to 30s to do.
+      consecutiveGatewayErrors: 3
+      interval: 5s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+{{ end }}

--- a/charts/ace/templates/gateway/route-main.yaml
+++ b/charts/ace/templates/gateway/route-main.yaml
@@ -38,9 +38,11 @@ spec:
       namespace: {{ .Release.Namespace }}
       port: 80
       weight: 1
-    timeouts: # They default to 15s.
-      backendRequest: 2m
-      request: 2m
+    # Kept under Cloudflare's 100s origin timeout so a slow backend surfaces as a
+    # gateway 504 rather than a Cloudflare 520/524. They default to 15s.
+    timeouts:
+      backendRequest: 55s
+      request: 55s
   - matches:
     - path:
         type: PathPrefix
@@ -53,8 +55,8 @@ spec:
       port: 80
       weight: 1
     timeouts:
-      backendRequest: 2m
-      request: 2m
+      backendRequest: 55s
+      request: 55s
   - matches:
     - path:
         type: PathPrefix
@@ -101,8 +103,8 @@ spec:
       port: 80
       weight: 1
     timeouts:
-      backendRequest: 2m
-      request: 2m
+      backendRequest: 55s
+      request: 55s
   {{- end }}
   {{- if (index .Values "perses" "enabled") }}
   - matches:
@@ -117,8 +119,8 @@ spec:
       port: 8080
       weight: 1
     timeouts:
-      backendRequest: 2m
-      request: 2m
+      backendRequest: 55s
+      request: 55s
   {{- end }}
   - matches:
     - path:
@@ -132,6 +134,6 @@ spec:
       port: 4000
       weight: 1
     timeouts:
-      backendRequest: 2m
-      request: 2m
+      backendRequest: 55s
+      request: 55s
 {{- end }}

--- a/charts/platform-api/templates/statefulset.yaml
+++ b/charts/platform-api/templates/statefulset.yaml
@@ -68,16 +68,26 @@ spec:
               port: http
             # wait for cert and nats to be ready
             initialDelaySeconds: 60
+            timeoutSeconds: 5
             failureThreshold: 18
             periodSeconds: 30
           livenessProbe:
             httpGet:
               path: /api/v1/version
               port: http
+            # /api/v1/version is served by the same process as every other request, so it
+            # stalls whenever the process does. Restart only a genuinely wedged process
+            # (~2m); the 1s/30s default kills all replicas together on transient slowness.
+            timeoutSeconds: 10
+            periodSeconds: 20
+            failureThreshold: 6
           readinessProbe:
             httpGet:
               path: /api/v1/version
               port: http
+            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.envFrom }}

--- a/charts/service-gateway/templates/gateway/gwclass.yaml
+++ b/charts/service-gateway/templates/gateway/gwclass.yaml
@@ -3,6 +3,7 @@
   "vaultServer" .Values.vaultServer
   "frontendTLSSecretRef" (dict "name" (printf "%s-gw-cert" (include "tenant.name" .)) "namespace" .Release.Namespace)
 }}
+{{- $multiReplica := and (eq .Values.envoy.provisionerType "Deployment") (gt (int (.Values.envoy.replicas | default 1)) 1) }}
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
@@ -57,10 +58,24 @@ spec:
           securityContext:
             {{- toYaml .Values.envoy.securityContext | nindent 12 }}
           {{- end }}
-        {{- if .Values.envoy.nodeSelector }}
+        {{- if or .Values.envoy.nodeSelector $multiReplica }}
         pod:
+          {{- with .Values.envoy.nodeSelector }}
           nodeSelector:
-            {{- toYaml .Values.envoy.nodeSelector | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if $multiReplica }}
+          topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            # ScheduleAnyway so a cluster with fewer nodes than replicas still schedules.
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: envoy
+                app.kubernetes.io/component: proxy
+                gateway.envoyproxy.io/owning-gatewayclass: {{ include "tenant.name" . }}
+          {{- end }}
         {{- end }}
         patch:
           value:
@@ -76,6 +91,11 @@ spec:
                     securityContext:
                       {{- toYaml .Values.envoy.securityContext | nindent 22 }}
                     {{- end }}
+
+      {{- if $multiReplica }}
+      envoyPDB:
+        maxUnavailable: 1
+      {{- end }}
 
       envoyService:
         {{- $extraDomains := list }}


### PR DESCRIPTION
Customer saw recurring 5xx (503/504/522/520 + SSL-closed) on `appscode.com/api/v1/dbaas/billing/reports/namespaces`. The handler is fine (112ms–1.84s, 0 5xx in 48h of Envoy logs); the failures come from the serving path.

**`charts/platform-api/templates/statefulset.yaml`** — liveness/readiness had only `httpGet`, so k8s defaults gave a 30s kill window. `/api/v1/version` is served by the same process as everything else, so it stalls when the process does: `ace-platform-api-2` logged 40s `/api/v1/version` responses, then `exitCode: 1` — no panic, no OOM. All replicas share `ace-db`/`ace-nats`, so they stalled and got killed together. Liveness now needs ~2m (`timeout 10`, `period 20`, `failureThreshold 6`); readiness keeps a tight period with a 5s timeout so it sheds traffic first. `startupProbe` gets a 5s timeout too.

**`charts/service-gateway`** — `envoy.replicas` was commented out, so envoy-gateway runs 1 replica with no PDB. Every appscode.com request transits that one pod; any reschedule is a domain outage (the customer's 522s stop exactly when the current envoy pod was created, Aug 6). Added `envoyPDB.maxUnavailable: 1` and a hostname topology spread (`ScheduleAnyway`), both gated on `replicas > 1` so single-replica and DaemonSet installs render unchanged. Default stays 1 — prod should set `service-gateway.envoy.replicas: 3`.

**`charts/ace/templates/gateway/route-main.yaml`** — `request`/`backendRequest` were `2m` in 5 places, above Cloudflare's 100s origin timeout, so anything in the 100–120s band surfaced as a Cloudflare 520/524 with nothing in our logs. Lowered to `55s`.

**New `BackendTrafficPolicy`** — without one, a single connection failure during a pod restart was returned to Cloudflare as a 503 even with healthy replicas left. Retries are limited to `connect-failure`, `refused-stream`, `reset-before-request` — all three guarantee the backend never processed the request, so `POST /api/v1/register` and `/api/v1/license/issue` stay safe without per-rule scoping. Passive health checking ejects a failing replica faster than readiness.

## Not in this PR

- Resource requests are already fixed in the chart (`ab61c162`); prod runs `platform-api-v2026.6.19` with `resources: {}`, hence `BestEffort` pods evicted first. Chart upgrade fixes it.
- `gotenberg` sidecar still has no `resources` — follow-up.
- `nats: no responders available` in the billing processor/aggregator is application-side; tracked separately.

## Verification

- `helm template` platform-api: probes render with intended thresholds.
- `helm template` service-gateway: `replicas=1` → no PDB/spread; `replicas=3` → both; DaemonSet unchanged.
- `kubectl apply --dry-run=server` accepts the new `BackendTrafficPolicy`, `HTTPRoute`, `EnvoyProxy`/`GatewayClass`.
- `helm lint` passes on both charts.
